### PR TITLE
Now sending 00 hex turns off the channel of led.

### DIFF
--- a/scripts/expled.sh
+++ b/scripts/expled.sh
@@ -49,6 +49,21 @@ echo "Setting LEDs to: $hex"
 echo "Duty: $rDuty $gDuty $bDuty"
 
 #run the pwm
-fast-gpio pwm 17 200 $rDuty
-fast-gpio pwm 16 200 $gDuty
-fast-gpio pwm 15 200 $bDuty
+#run the pwm                  
+if [ $rHex != "00" ]; then        
+        fast-gpio pwm 17 200 $rDuty;  
+else                                             
+        fast-gpio set 17 1            
+fi;                                              
+                                      
+if [ $gHex != "00" ]; then    
+        fast-gpio pwm 16 200 $gDuty;
+else                          
+        fast-gpio set 16 1          
+fi;                              
+                            
+if [ $bHex != "00" ]; then       
+        fast-gpio pwm 15 200 $bDuty;
+else                      
+        fast-gpio set 15 1          
+fi;             


### PR DESCRIPTION
`expled ff0000` is a command that never turned in a real led, instead a mix of 3 colors. `expled 000000` now set gpio led state as 1 instead of sending a 100 duty PWM.
